### PR TITLE
Specify libraries after the object file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,4 @@ clean:
 	rm -f invaders.o ascii_invaders
 
 ascii_invaders: invaders.o
-	$(CC) $(CFLAGS) $(LDFLAGS) $(LIBS) invaders.o -o ascii_invaders
-
+	$(CC) $(CFLAGS) $(LDFLAGS) invaders.o $(LIBS) -o ascii_invaders


### PR DESCRIPTION
For linking statically, the libraries must be specified after the
object file, or the linker fails to resolve the symbols.